### PR TITLE
Change all of MelonLogger to the newer method

### DIFF
--- a/ClassicPlates/AssetManager.cs
+++ b/ClassicPlates/AssetManager.cs
@@ -19,13 +19,13 @@ internal static class AssetManager
     {
         if (_bundle is null)
         {
-            MelonLogger.Error("Failed to load Prefab: " + @object);
+            ClassicPlates.Error($"Failed to load Prefab: {@object}");
             throw new FileLoadException();
         }
         var go = _bundle.LoadAsset_Internal(@object, Il2CppType.Of<GameObject>()).Cast<GameObject>();
         go.hideFlags |= HideFlags.DontUnloadUnusedAsset;
         go.hideFlags = HideFlags.HideAndDontSave;
-        MelonDebug.Msg("Loaded Prefab: " + @object);
+        ClassicPlates.Debug($"Loaded Prefab: {@object}");
         return go;
     }
 
@@ -33,13 +33,13 @@ internal static class AssetManager
     {
         if (_bundle is null)
         {
-            MelonLogger.Error("Failed to load Sprite: " + sprite);
+            ClassicPlates.Error($"Failed to load Sprite: {sprite}");
             throw new FileLoadException();
         }
         var sprite2 = _bundle.LoadAsset_Internal(sprite, Il2CppType.Of<Sprite>()).Cast<Sprite>();
         sprite2.hideFlags |= HideFlags.DontUnloadUnusedAsset;
         sprite2.hideFlags = HideFlags.HideAndDontSave;
-        MelonDebug.Msg("Loaded Sprite: " + sprite);
+        ClassicPlates.Debug($"Loaded Sprite: {sprite}");
         return sprite2;
     }
 
@@ -130,12 +130,12 @@ internal static class AssetManager
             }
             catch (Exception e)
             {
-                MelonLogger.Error($"Nameplate Assets failed to load\n\n{e}");
+                ClassicPlates.Error($"Nameplate Assets failed to load\n\n{e}");
             }
         }
         else
         {
-            MelonLogger.Error("Stream is null, Nameplates cannot load");
+            ClassicPlates.Error("Stream is null, Nameplates cannot load");
         }
 
         yield break;

--- a/ClassicPlates/ClassicPlates.cs
+++ b/ClassicPlates/ClassicPlates.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using ClassicPlates.Patching;
+using Il2CppSystem.Linq;
 using MelonLoader;
 using VRC;
 
@@ -14,8 +15,9 @@ namespace ClassicPlates;
 //TODO: Nameplate Stats Compatibility
 //TODO: TW/ReMod/BTK Compatibility
 //TODO: Hook into OnSocialRank change
-public class ClassicPlates : MelonMod
-{
+public class ClassicPlates : MelonMod {
+    private static MelonLogger.Instance _logger = new MelonLogger.Instance("ClassicNameplates");
+
     public static NameplateManager? NameplateManager;
 
     public override void OnApplicationStart()
@@ -75,8 +77,22 @@ public class ClassicPlates : MelonMod
         }
         else
         {
-            MelonDebug.Msg("Not in Room, clearing any straggler Nameplates");
+            Debug("Not in Room, clearing any straggler Nameplates");
             NameplateManager.ClearNameplates();
         }
+    }
+
+    internal static void Log(object msg) => _logger.Msg(msg);
+
+    internal static void Debug(object msg) {
+        if (MelonDebug.IsEnabled())
+            _logger.Msg(ConsoleColor.Cyan, msg);
+    }
+
+    internal static void Error(object obj) => _logger.Error(obj);
+
+    internal static void DebugError(object obj) {
+        if (MelonDebug.IsEnabled())
+            _logger.Error($"[DEBUG] {obj}");
     }
 }

--- a/ClassicPlates/ClassicPlates.csproj
+++ b/ClassicPlates/ClassicPlates.csproj
@@ -5,94 +5,92 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
-        <AssemblyName>ClassicPlates.dev</AssemblyName>
+        <AssemblyName>ClassicPlates</AssemblyName>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <AssemblyOriginatorKeyFile>FS_Signed.snk</AssemblyOriginatorKeyFile>
         <PublicSign>false</PublicSign>
+		<VRChatPath>C:\Program Files (x86)\Steam\steamapps\common\VRChat</VRChatPath>
     </PropertyGroup>
 
     <ItemGroup>
       <Reference Include="0Harmony, Version=2.9.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\0Harmony.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\0Harmony.dll</HintPath>
       </Reference>
       <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\Assembly-CSharp.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\Assembly-CSharp.dll</HintPath>
       </Reference>
       <Reference Include="DataModel">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat_ML6\MelonLoader\Managed\DataModel.dll</HintPath>
-      </Reference>
-      <Reference Include="DataModel, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\DataModel.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\DataModel.dll</HintPath>
       </Reference>
       <Reference Include="Il2Cppmscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\Il2Cppmscorlib.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\Il2Cppmscorlib.dll</HintPath>
       </Reference>
       <Reference Include="Il2CppSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\Il2CppSystem.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\Il2CppSystem.dll</HintPath>
       </Reference>
       <Reference Include="Il2CppSystem.Core">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\Il2CppSystem.Core.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\Il2CppSystem.Core.dll</HintPath>
       </Reference>
       <Reference Include="MelonLoader, Version=0.5.4.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\MelonLoader.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\MelonLoader.dll</HintPath>
       </Reference>
       <Reference Include="Microsoft.CSharp" />
       <Reference Include="Newtonsoft.Json">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat_ML6\MelonLoader\Managed\Newtonsoft.Json.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\Newtonsoft.Json.dll</HintPath>
       </Reference>
       <Reference Include="Photon-DotNet">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat_ML6\MelonLoader\Managed\Photon-DotNet.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\Photon-DotNet.dll</HintPath>
       </Reference>
       <Reference Include="UnhollowerBaseLib, Version=0.4.17.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\UnhollowerBaseLib.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\UnhollowerBaseLib.dll</HintPath>
       </Reference>
       <Reference Include="Unity.TextMeshPro, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\Unity.TextMeshPro.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\Unity.TextMeshPro.dll</HintPath>
       </Reference>
       <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\UnityEngine.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\UnityEngine.dll</HintPath>
       </Reference>
       <Reference Include="UnityEngine.AnimationModule">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat_ML6\MelonLoader\Managed\UnityEngine.AnimationModule.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\UnityEngine.AnimationModule.dll</HintPath>
       </Reference>
       <Reference Include="UnityEngine.AssetBundleModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
       </Reference>
       <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\UnityEngine.CoreModule.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\UnityEngine.CoreModule.dll</HintPath>
       </Reference>
       <Reference Include="UnityEngine.ImageConversionModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
       </Reference>
       <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\UnityEngine.IMGUIModule.dll</HintPath>
       </Reference>
       <Reference Include="UnityEngine.InputLegacyModule">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat_ML6\MelonLoader\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
       </Reference>
       <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\UnityEngine.UI.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\UnityEngine.UI.dll</HintPath>
       </Reference>
       <Reference Include="UnityEngine.UnityWebRequestModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
       </Reference>
       <Reference Include="UnityEngine.UnityWebRequestTextureModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
       </Reference>
       <Reference Include="UnityEngine.UnityWebRequestWWWModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
       </Reference>
       <Reference Include="VRC.UI.Core">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat_ML6\MelonLoader\Managed\VRC.UI.Core.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\VRC.UI.Core.dll</HintPath>
       </Reference>
       <Reference Include="VRC.UI.Elements">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat_ML6\MelonLoader\Managed\VRC.UI.Elements.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\VRC.UI.Elements.dll</HintPath>
       </Reference>
       <Reference Include="VRCCore-Standalone, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\VRCCore-Standalone.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\VRCCore-Standalone.dll</HintPath>
       </Reference>
       <Reference Include="VRCSDKBase, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>X:\SteamLibrary\steamapps\common\VRChat\MelonLoader\Managed\VRCSDKBase.dll</HintPath>
+        <HintPath>$(VRChatPath)\MelonLoader\Managed\VRCSDKBase.dll</HintPath>
       </Reference>
     </ItemGroup>
 

--- a/ClassicPlates/MonoScripts/OldNameplate.cs
+++ b/ClassicPlates/MonoScripts/OldNameplate.cs
@@ -421,7 +421,7 @@ public class OldNameplate : MonoBehaviour
                 }
                 default:
                 {
-                    MelonLogger.Error("Unknown performance rating: " + _performance);
+                    ClassicPlates.Error("Unknown performance rating: " + _performance);
                     break;
                 }
             }
@@ -436,7 +436,7 @@ public class OldNameplate : MonoBehaviour
             _avatarKind = value;
             if (SpriteDict == null || _badgeFallback == null || _badgePerformance == null ||
                 Settings.ShowFallback == null || Settings.ShowPerformance == null) return;
-            if (player != null) MelonDebug.Msg($"{player.prop_APIUser_0.displayName}'s Avatar kind: " + _avatarKind);
+            if (player != null) ClassicPlates.Debug($"{player.prop_APIUser_0.displayName}'s Avatar kind: " + _avatarKind);
             switch (_avatarKind)
             {
                 case AvatarKind.Undefined:
@@ -494,7 +494,7 @@ public class OldNameplate : MonoBehaviour
 
                 default:
                 {
-                    MelonLogger.Error("Unknown avatar kind: " + _avatarKind);
+                    ClassicPlates.Error("Unknown avatar kind: " + _avatarKind);
                     break;
                 }
             }
@@ -662,12 +662,12 @@ public class OldNameplate : MonoBehaviour
                 if (_constraint == null)
                 {
                     _constraint = Nameplate!.AddComponent<PositionConstraint>();
-                    MelonLogger.Error("Constraint is null, forcefully adding it.");
+                    ClassicPlates.Error("Constraint is null, forcefully adding it.");
                 }
 
                 if (_constraint.sourceCount > 1)
                 {
-                    MelonLogger.Error("Constraint.sourceCount is greater than 1, resetting...");
+                    ClassicPlates.Error("Constraint.sourceCount is greater than 1, resetting...");
                     _constraint.SetSources(null);
                 }
 
@@ -675,7 +675,7 @@ public class OldNameplate : MonoBehaviour
                 {
                     if (_constraint.GetSource(0).sourceTransform == null)
                     {
-                        MelonDebug.Msg("Removing Null Constraint Source");
+                        ClassicPlates.Debug("Removing Null Constraint Source");
                         _constraint.RemoveSource(0);
                     }
                 }
@@ -691,7 +691,7 @@ public class OldNameplate : MonoBehaviour
                         });
                     else
                     {
-                        MelonLogger.Error("Could not create constraint, player is null.");
+                        ClassicPlates.Error("Could not create constraint, player is null.");
                     }
                 }
             }
@@ -746,7 +746,7 @@ public class OldNameplate : MonoBehaviour
                     {
                         PlateColor = Color.green;
                         Settings.PlateColor.Value = "#00FF00";
-                        Debug.LogError("Invalid color string for nameplate color.");
+                        ClassicPlates.DebugError("Invalid color string for nameplate color.");
                     }
                 }
             }
@@ -766,7 +766,7 @@ public class OldNameplate : MonoBehaviour
                     {
                         NameColor = Color.white;
                         Settings.NameColor.Value = "#FFFFFF";
-                        Debug.LogError("Invalid color string for name color.");
+                        ClassicPlates.DebugError("Invalid color string for name color.");
                     }
                 }
             }
@@ -812,14 +812,14 @@ public class OldNameplate : MonoBehaviour
 
                 if (IsLocal)
                 {
-                    MelonDebug.Msg("Local Player");
+                    ClassicPlates.Debug("Local Player");
                     if (Nameplate != null) Nameplate.active = false;
                 }
             }
         }
         catch (Exception e)
         {
-            MelonLogger.Error("Unable to Apply Nameplate Settings: " + e);
+            ClassicPlates.Error("Unable to Apply Nameplate Settings: " + e);
         }
     }
 

--- a/ClassicPlates/NameplateManager.cs
+++ b/ClassicPlates/NameplateManager.cs
@@ -82,12 +82,9 @@ public class NameplateManager
         {
             return nameplate;
         }
-        else
-        {
-            MelonDebug.Error("Nameplate does not exist in Dictionary for player: " +
-                              player._player.prop_APIUser_0.displayName);
-            return null;
-        }
+
+        ClassicPlates.DebugError($"Nameplate does not exist in Dictionary for player: {player._player.prop_APIUser_0.displayName}");
+        return null;
     }
 
     public OldNameplate? GetNameplate(string id)
@@ -96,11 +93,9 @@ public class NameplateManager
         {
             return nameplate;
         }
-        else
-        {
-            MelonDebug.Error("Nameplate does not exist in Dictionary for player: " + id);
-            return null;
-        }
+
+        ClassicPlates.DebugError($"Nameplate does not exist in Dictionary for player: {id}");
+        return null;
     }
 
     public void ClearNameplates()
@@ -144,7 +139,7 @@ public class NameplateManager
                 }
                 catch
                 {
-                    MelonLogger.Error("Failed to set player on nameplate");
+                    ClassicPlates.Error("Failed to set player on nameplate");
                 }
 
                 if (oldNameplate.player != null)
@@ -155,7 +150,7 @@ public class NameplateManager
                     }
                     catch
                     {
-                        MelonLogger.Error("Failed to set name on nameplate");
+                        ClassicPlates.Error("Failed to set name on nameplate");
                     }
 
                     try
@@ -164,7 +159,7 @@ public class NameplateManager
                     }
                     catch
                     {
-                        MelonLogger.Error("Failed to set status on nameplate");
+                        ClassicPlates.Error("Failed to set status on nameplate");
                     }
 
                     try
@@ -174,7 +169,7 @@ public class NameplateManager
                     }
                     catch
                     {
-                        MelonLogger.Error("Failed to set rank on nameplate");
+                        ClassicPlates.Error("Failed to set rank on nameplate");
                     }
 
                     try
@@ -183,7 +178,7 @@ public class NameplateManager
                     }
                     catch
                     {
-                        MelonLogger.Error("Failed to set friend status on nameplate");
+                        ClassicPlates.Error("Failed to set friend status on nameplate");
                     }
 
                     try
@@ -193,7 +188,7 @@ public class NameplateManager
                     }
                     catch
                     {
-                        MelonLogger.Error("Failed to set master status on nameplate");
+                        ClassicPlates.Error("Failed to set master status on nameplate");
                     }
 
                     try
@@ -205,7 +200,7 @@ public class NameplateManager
                     }
                     catch
                     {
-                        MelonLogger.Error("Failed to set user volume on nameplate");
+                        ClassicPlates.Error("Failed to set user volume on nameplate");
                     }
 
                     try
@@ -214,7 +209,7 @@ public class NameplateManager
                     }
                     catch
                     {
-                        MelonLogger.Error("Failed to set profile picture on nameplate");
+                        ClassicPlates.Error("Failed to set profile picture on nameplate");
                     }
 
                     try
@@ -223,7 +218,7 @@ public class NameplateManager
                     }
                     catch
                     {
-                        MelonLogger.Error("Failed to set quest status on nameplate");
+                        ClassicPlates.Error("Failed to set quest status on nameplate");
                     }
 
                     try
@@ -233,7 +228,7 @@ public class NameplateManager
                     }
                     catch
                     {
-                        MelonLogger.Error("Failed to set vip status on nameplate");
+                        ClassicPlates.Error("Failed to set vip status on nameplate");
                     }
 
                     try
@@ -242,7 +237,7 @@ public class NameplateManager
                     }
                     catch
                     {
-                        MelonLogger.Error("Failed to set local setting on nameplate");
+                        ClassicPlates.Error("Failed to set local setting on nameplate");
                     }
 
                     if (_enableDisableListener != null)
@@ -252,7 +247,7 @@ public class NameplateManager
                     }
                     else
                     {
-                        MelonLogger.Error("EnableDisableListener is null");
+                        ClassicPlates.Error("EnableDisableListener is null");
                     }
 
                     try
@@ -262,7 +257,7 @@ public class NameplateManager
                     }
                     catch
                     {
-                        MelonLogger.Error("Failed to set avatar kind on nameplate");
+                        ClassicPlates.Error("Failed to set avatar kind on nameplate");
                     }
 
                     try
@@ -274,7 +269,7 @@ public class NameplateManager
                     }
                     catch
                     {
-                        MelonLogger.Error("Failed to set performance on nameplate");
+                        ClassicPlates.Error("Failed to set performance on nameplate");
                     }
 
                     try
@@ -299,7 +294,7 @@ public class NameplateManager
                         }
                         else
                         {
-                            MelonDebug.Msg("No Moderations for: " + player.field_Private_APIUser_0.id);
+                            ClassicPlates.Debug("No Moderations for: " + player.field_Private_APIUser_0.id);
                             oldNameplate.IsMuted = false;
                             oldNameplate.IsBlocked = false;
                         }
@@ -308,7 +303,7 @@ public class NameplateManager
                     {
                         oldNameplate.IsMuted = false;
                         oldNameplate.IsBlocked = false;
-                        MelonLogger.Error("Failed to set mute/block status on nameplate, defaulting to false");
+                        ClassicPlates.Error("Failed to set mute/block status on nameplate, defaulting to false");
                     }
                 }
                 else
@@ -319,12 +314,12 @@ public class NameplateManager
             }
             catch (Exception e)
             {
-                MelonLogger.Error("Unable to Initialize Nameplate: " + e);
+                ClassicPlates.Error("Unable to Initialize Nameplate: " + e);
             }
         }
         else
         {
-            MelonLogger.Error("Unable to Initialize Nameplate: Player is null");
+            ClassicPlates.Error("Unable to Initialize Nameplate: Player is null");
         }
     }
 
@@ -334,7 +329,7 @@ public class NameplateManager
         {
             if (_cachedImage.TryGetValue(url, out var tex))
             {
-                MelonDebug.Msg("Found Cached Image for: " + url);
+                ClassicPlates.Debug("Found Cached Image for: " + url);
             }
             else
             {
@@ -355,7 +350,7 @@ public class NameplateManager
                     try
                     {
                         //I do Dis
-                        MelonDebug.Msg($"Download Finished: {url}");
+                        ClassicPlates.Debug($"Download Finished: {url}");
                         tex = new Texture2D(2, 2)
                         {
                             hideFlags = HideFlags.DontUnloadUnusedAsset,
@@ -367,11 +362,11 @@ public class NameplateManager
                         // Compiles incorrectly if called as an extension. Why? Who knows
                         if (ImageConversion.LoadImage(tex, bytes))
                         {
-                            MelonDebug.Msg("Loading Using LoadImage...");
+                            ClassicPlates.Debug("Loading Using LoadImage...");
                         }
                         else
                         {
-                            MelonDebug.Msg("Loading using LoadRawTextureData...");
+                            ClassicPlates.Debug("Loading using LoadRawTextureData...");
                             tex.LoadRawTextureData(bytes);
                         }
 
@@ -379,12 +374,12 @@ public class NameplateManager
                     }
                     catch (Exception e)
                     {
-                        MelonLogger.Error(e.ToString());
+                        ClassicPlates.Error(e.ToString());
                     }
                 }
                 else
                 {
-                    MelonLogger.Error("Image Request Failed");
+                    ClassicPlates.Error("Image Request Failed");
                 }
 
                 http.Dispose();
@@ -394,18 +389,18 @@ public class NameplateManager
             {
                 image.texture = tex;
                 if (Settings.ShowIcon != null) image.transform.parent.gameObject.active = Settings.ShowIcon.Value;
-                MelonDebug.Msg("Applying Image");
+                ClassicPlates.Debug("Applying Image");
             }
             else
             {
-                MelonLogger.Error("Texture is Unreadable: " + url);
+                ClassicPlates.Error("Texture is Unreadable: " + url);
                 _cachedImage.Remove(url);
                 image.transform.parent.gameObject.active = false;
             }
         }
         else
         {
-            MelonLogger.Error("Image Cache is Null");
+            ClassicPlates.Error("Image Cache is Null");
         }
     }
 
@@ -430,7 +425,7 @@ public class NameplateManager
                     }
                     else
                     {
-                        MelonLogger.Error("Unable to Instantiate Nameplate: Nameplate is Null");
+                        ClassicPlates.Error("Unable to Instantiate Nameplate: Nameplate is Null");
                     }
                 }
                 else
@@ -448,7 +443,7 @@ public class NameplateManager
                     }
                     else
                     {
-                        MelonLogger.Error("Unable to Instantiate Nameplate: Nameplate is Null");
+                        ClassicPlates.Error("Unable to Instantiate Nameplate: Nameplate is Null");
                     }
                 }
 
@@ -473,12 +468,12 @@ public class NameplateManager
             }
             else
             {
-                MelonLogger.Error("Unable to Instantiate Nameplate: Player is Null");
+                ClassicPlates.Error("Unable to Instantiate Nameplate: Player is Null");
             }
         }
         else
         {
-            MelonLogger.Error("Unable to Initialize Nameplate: Settings are null");
+            ClassicPlates.Error("Unable to Initialize Nameplate: Settings are null");
         }
     }
 }

--- a/ClassicPlates/Patching/Patching.cs
+++ b/ClassicPlates/Patching/Patching.cs
@@ -27,7 +27,7 @@ internal static class Patching
         }
         catch (Exception e)
         {
-            MelonLogger.Error(e);
+            ClassicPlates.Error(e);
         }
 
         try
@@ -38,7 +38,7 @@ internal static class Patching
         }
         catch (Exception e)
         {
-            MelonLogger.Error(e);
+            ClassicPlates.Error(e);
         }
 
         try
@@ -49,7 +49,7 @@ internal static class Patching
         }
         catch (Exception e)
         {
-            MelonLogger.Error(e);
+            ClassicPlates.Error(e);
         }
 
         try
@@ -60,7 +60,7 @@ internal static class Patching
         }
         catch (Exception e)
         {
-            MelonLogger.Error(e);
+            ClassicPlates.Error(e);
         }
 
         try
@@ -73,7 +73,7 @@ internal static class Patching
         }
         catch (Exception e)
         {
-            MelonLogger.Error(e);
+            ClassicPlates.Error(e);
         }
 
         try
@@ -88,7 +88,7 @@ internal static class Patching
         }
         catch (Exception e)
         {
-            MelonLogger.Error(e);
+            ClassicPlates.Error(e);
         }
 
         try
@@ -99,7 +99,7 @@ internal static class Patching
         }
         catch (Exception e)
         {
-            MelonLogger.Error(e);
+            ClassicPlates.Error(e);
         }
 
         //TODO: Add Avatar Loading Bar
@@ -113,18 +113,17 @@ internal static class Patching
         }
         catch (Exception e)
         {
-            MelonLogger.Error(e);
+            ClassicPlates.Error(e);
         }*/
-        
-        try
-        {
+
+        try {
             _instance.Patch(typeof(FriendsListManager).GetMethod("Method_Private_Void_String_0"), new HarmonyMethod(
                 typeof(Patching).GetMethod(nameof(OnUnfriend),
                     BindingFlags.NonPublic | BindingFlags.Static)));
         }
         catch (Exception e)
         {
-            MelonLogger.Error(e);
+            ClassicPlates.Error(e);
         }
 
         try
@@ -135,7 +134,7 @@ internal static class Patching
         }
         catch (Exception e)
         {
-            MelonLogger.Error(e);
+            ClassicPlates.Error(e);
         }
 
         try
@@ -148,7 +147,7 @@ internal static class Patching
         }
         catch (Exception e)
         {
-            MelonLogger.Error(e);
+            ClassicPlates.Error(e);
         }
         
         try
@@ -161,7 +160,7 @@ internal static class Patching
         }
         catch (Exception e)
         {
-            MelonLogger.Error(e);
+            ClassicPlates.Error(e);
         }
     }
 
@@ -204,7 +203,7 @@ internal static class Patching
         }
         else
         {
-            MelonLogger.Error("Master Change Detected, but player was null");
+            ClassicPlates.Error("Master Change Detected, but player was null");
         }
     }
 
@@ -223,21 +222,21 @@ internal static class Patching
     private static void OnPlayerModerationSend1(string __1, ApiPlayerModeration.ModerationType __2)
     {
         if (__1 == null) return;
-        MelonDebug.Msg("PlayerModerationSend1");
+        ClassicPlates.Debug("PlayerModerationSend1");
         UpdateModeration(__1, __2);
     }
     
     private static void OnPlayerModerationSend2(string __0, ApiPlayerModeration.ModerationType __1)
     {
         if (__0 == null) return;
-        MelonDebug.Msg("OnPlayerModerationSend2");
+        ClassicPlates.Debug("OnPlayerModerationSend2");
         UpdateModeration(__0, __1);
     }
     
     private static void OnPlayerModerationRemove(string __0, ApiPlayerModeration.ModerationType __1)
     {
         if (__0 == null) return;
-        MelonDebug.Msg("OnPlayerModerationRemove");
+        ClassicPlates.Debug("OnPlayerModerationRemove");
         RemoveModeration(__0, __1);
     }
     
@@ -258,18 +257,18 @@ internal static class Patching
     private static void OnNameplateModeUpdate(/*VRC.NameplateManager __instance,*/ VRC.NameplateManager.NameplateMode __0)
     {
         Settings.NameplateMode = __0;
-        MelonDebug.Msg("OnNameplateModeUpdate: " + __0);
+        ClassicPlates.Debug("OnNameplateModeUpdate: " + __0);
     }
     
     private static void OnStatusModeUpdate(/*VRC.NameplateManager __instance,*/ VRC.NameplateManager.StatusMode __0)
     {
-        MelonDebug.Msg("OnStatusModeUpdate: " + __0);
+        ClassicPlates.Debug("OnStatusModeUpdate: " + __0);
         Settings.StatusMode = __0;
     }
 
     private static void RemoveModeration(string id, ApiPlayerModeration.ModerationType type)
     {
-        MelonLogger.Msg("Moderation Removed for user: " + id + " | Type: " + type);
+        ClassicPlates.Log("Moderation Removed for user: " + id + " | Type: " + type);
 
         if (ClassicPlates.NameplateManager == null) return;
         var oldNameplate = ClassicPlates.NameplateManager.GetNameplate(id);
@@ -318,7 +317,7 @@ internal static class Patching
 
     private static void UpdateModeration(string id, ApiPlayerModeration.ModerationType type)
     {
-        MelonLogger.Msg("Moderation Sent for user: " + id + " | Type: " + type);
+        ClassicPlates.Log("Moderation Sent for user: " + id + " | Type: " + type);
 
         if (ClassicPlates.NameplateManager == null) return;
         var oldNameplate = ClassicPlates.NameplateManager.GetNameplate(id);

--- a/ClassicPlates/Patching/PhotonUtils.cs
+++ b/ClassicPlates/Patching/PhotonUtils.cs
@@ -24,64 +24,64 @@ public static class PhotonUtils
             .TryCast<Il2CppSystem.Collections.Generic.Dictionary<byte, Object>>();
 
         var moderation = new Moderation();
-        MelonDebug.Msg("Handling Moderation Event...");
+        ClassicPlates.Debug("Handling Moderation Event...");
         if (moderationDict != null)
         {
             if (moderationDict[0].Unbox<byte>() != 21)
             {
-                MelonDebug.Msg("Redundant Moderation Event, Skipping...");
+                ClassicPlates.Debug("Redundant Moderation Event, Skipping...");
                 return;
             }
 
             if (moderationDict.ContainsKey(1))
             {
-                MelonDebug.Msg("Player Moderation Event...");
+                ClassicPlates.Debug("Player Moderation Event...");
 
                 moderation.Player = moderationDict[1].Unbox<int>();
-                MelonDebug.Msg("Player: " + moderation.Player);
+                ClassicPlates.Debug("Player: " + moderation.Player);
 
                 if (moderationDict.ContainsKey(10))
                 {
                     var block = moderationDict[10].Unbox<bool>();
                     moderation.Blocked = block;
-                    MelonDebug.Msg(
+                    ClassicPlates.Log(
                         $"Block Status: {(moderation.Blocked.Value ? "Blocked" : "Unblocked")}");
                 }
                 else
                 {
-                    MelonDebug.Msg("Block Status: Null");
+                    ClassicPlates.Debug("Block Status: Null");
                 }
 
                 if (moderationDict.ContainsKey(11))
                 {
                     var mute = moderationDict[11].Unbox<bool>();
                     moderation.Muted = mute;
-                    MelonDebug.Msg(
+                    ClassicPlates.Log(
                         $"Mute Status: {(moderation.Muted.Value ? "Muted" : "Unmuted")}");
                 }
                 else
                 {
-                    MelonDebug.Msg("Mute Status: Null");
+                    ClassicPlates.Debug("Mute Status: Null");
                 }
                 ApplyModerations(moderation);
             }
             else
             {
-                MelonDebug.Msg("Cached Moderation Event...");
+                ClassicPlates.Debug("Cached Moderation Event...");
                 var blocks = Il2CppArrayBase<int>.WrapNativeGenericArrayPointer(moderationDict[10].Pointer);
                 var mutes = Il2CppArrayBase<int>.WrapNativeGenericArrayPointer(moderationDict[11].Pointer);
 
                 if (blocks is {Length: > 0})
                     foreach (var i in blocks)
                     {
-                        MelonDebug.Msg($"Queued Block: {i}");
+                        ClassicPlates.Debug($"Queued Block: {i}");
                         QueuedBlocks.Add(i);
                     }
 
                 if (mutes is {Length: > 0})
                     foreach (var i in mutes)
                     {
-                        MelonDebug.Msg($"Queued Mute: {i}");
+                        ClassicPlates.Debug($"Queued Mute: {i}");
                         QueuedMutes.Add(i);
                     }
                 
@@ -90,7 +90,7 @@ public static class PhotonUtils
         }
         else
         {
-            MelonDebug.Error("Moderation Dictionary is null, Skipping...");
+            ClassicPlates.DebugError("Moderation Dictionary is null, Skipping...");
         }
     }
     
@@ -114,7 +114,7 @@ public static class PhotonUtils
                         var key = intArr.Last();
                         if (!intArr.Remove(key))
                         {
-                            MelonLogger.Error("Failed to remove local key from interaction array");
+                            ClassicPlates.Error("Failed to remove local key from interaction array");
                         }
 
                         if (intArr.Contains(localID))
@@ -124,12 +124,12 @@ public static class PhotonUtils
                     }
                     else
                     {
-                        MelonDebug.Msg("Interaction Array is too short, Skipping...");
+                        ClassicPlates.Debug("Interaction Array is too short, Skipping...");
                     }
                 }
                 else
                 {
-                    MelonLogger.Error("Player Interaction Array is null, Skipping...");
+                    ClassicPlates.Error("Player Interaction Array is null, Skipping...");
                 }
             }
 
@@ -141,7 +141,7 @@ public static class PhotonUtils
                     if (plate == null) continue;
                     if (plate.player == null) continue;
                     var isInteractable = interactions.Contains(plate.player.prop_Int32_0);
-                    MelonDebug.Msg(
+                    ClassicPlates.Debug(
                         $"User: {plate.player.field_Private_APIUser_0.displayName} Interaction: {isInteractable}");
                     plate.Interactable = isInteractable;
                 }
@@ -153,7 +153,7 @@ public static class PhotonUtils
         }
         else
         {
-            MelonLogger.Error("Interaction Array is null, Skipping...");
+            ClassicPlates.Error("Interaction Array is null, Skipping...");
         }
     }
 
@@ -170,7 +170,7 @@ public static class PhotonUtils
             if (plate == null) continue;
             if (plate.player == null) continue;
             var isInteractable = interactions.Contains(plate.player.prop_Int32_0);
-            MelonDebug.Msg($"User: {plate.player.field_Private_APIUser_0.displayName} Interaction: {isInteractable}");
+            ClassicPlates.Debug($"User: {plate.player.field_Private_APIUser_0.displayName} Interaction: {isInteractable}");
             plate.Interactable = isInteractable;
         }
     }
@@ -208,11 +208,11 @@ public static class PhotonUtils
                                 {
                                     var plate = ClassicPlates.NameplateManager.GetNameplate(cachedPlayer.ID);
 
-                                    MelonDebug.Msg("Applying Moderation for Player: " + cachedPlayer.ID);
+                                    ClassicPlates.Debug("Applying Moderation for Player: " + cachedPlayer.ID);
                                     if (plate == null || moderation.Blocked == null || moderation.Muted == null)
                                         return;
-                                    MelonDebug.Msg("Block Status: " + moderation.Blocked.Value);
-                                    MelonDebug.Msg("Mute Status: " + moderation.Muted.Value);
+                                    ClassicPlates.Debug("Block Status: " + moderation.Blocked.Value);
+                                    ClassicPlates.Debug("Mute Status: " + moderation.Muted.Value);
 
                                     plate.IsBlocked = moderation.Blocked.Value;
                                     plate.IsMutedBy = moderation.Muted.Value;
@@ -228,28 +228,28 @@ public static class PhotonUtils
                                     }
                                     else
                                     {
-                                        MelonDebug.Msg("Moderation is empty, skipping...");
+                                        ClassicPlates.Debug("Moderation is empty, skipping...");
                                     }
                                 }
                             }
                             else
                             {
-                                MelonLogger.Error("Failed to get Photon Player for Moderation");
+                                ClassicPlates.Error("Failed to get Photon Player for Moderation");
                             }
                         }
                         else
                         {
-                            MelonLogger.Error("Failed to get Nameplate Manager");
+                            ClassicPlates.Error("Failed to get Nameplate Manager");
                         }
                     }
                     else
                     {
-                        MelonLogger.Error("Failed to get Player for Moderation");
+                        ClassicPlates.Error("Failed to get Player for Moderation");
                     }
                 }
                 else
                 {
-                    MelonDebug.Msg("Room was null, caching moderation...");
+                    ClassicPlates.Debug("Room was null, caching moderation...");
                     var player = GetPhotonPlayer(moderation.Player.Value);
                     if (player != null)
                     {
@@ -257,18 +257,18 @@ public static class PhotonUtils
                     }
                     else
                     {
-                        MelonLogger.Error("Unable to Cache Moderation, Photon Player was null");
+                        ClassicPlates.Error("Unable to Cache Moderation, Photon Player was null");
                     }
                 }
             }
             else
             {
-                MelonLogger.Error("Unable to Cache Moderation, Player was null");
+                ClassicPlates.Error("Unable to Cache Moderation, Player was null");
             }
         }
         else
         {
-            MelonLogger.Error("Unable to Cache Moderation, Moderation was null");
+            ClassicPlates.Error("Unable to Cache Moderation, Moderation was null");
         }
     }
 
@@ -277,7 +277,7 @@ public static class PhotonUtils
         if(ClassicPlates.NameplateManager == null) {return;}
         if (!(QueuedBlocks.Count > 0 | QueuedMutes.Count > 0))
         {
-            MelonDebug.Msg("No Queued Moderations");
+            ClassicPlates.Debug("No Queued Moderations");
             return;
         }
 
@@ -288,19 +288,19 @@ public static class PhotonUtils
                 if (ClassicPlates.NameplateManager.Nameplates.ContainsKey(cachedPlayer.ID))
                 {
                     var plate = ClassicPlates.NameplateManager.GetNameplate(cachedPlayer.ID);
-                    MelonDebug.Msg("Applying Queued Mute for Player: " + cachedPlayer.ID);
+                    ClassicPlates.Debug("Applying Queued Mute for Player: " + cachedPlayer.ID);
 
                     if (plate != null) plate.IsMutedBy = true;
                 }
                 else
                 {
-                    MelonDebug.Msg("Nameplate not found, Queuing Mute...");
+                    ClassicPlates.Debug("Nameplate not found, Queuing Mute...");
                     MelonCoroutines.Start(QueueModeration(cachedPlayer));
                 }
             }
             else
             {
-                MelonLogger.Error("Failed to Apply Moderation, Player was Null");
+                ClassicPlates.Error("Failed to Apply Moderation, Player was Null");
             }
         }
 
@@ -311,20 +311,20 @@ public static class PhotonUtils
                 if (ClassicPlates.NameplateManager.Nameplates.ContainsKey(cachedPlayer.ID))
                 {
                     var plate = ClassicPlates.NameplateManager.GetNameplate(cachedPlayer.ID);
-                    MelonDebug.Msg("Applying Queued Block for Player: " + cachedPlayer.ID);
+                    ClassicPlates.Debug("Applying Queued Block for Player: " + cachedPlayer.ID);
 
                     if (plate != null)
                         plate.IsBlocked = true;
                 }
                 else
                 {
-                    MelonDebug.Msg("Nameplate not found, Queuing Block...");
+                    ClassicPlates.Debug("Nameplate not found, Queuing Block...");
                     MelonCoroutines.Start(QueueModeration(cachedPlayer, true));
                 }
             }
             else
             {
-                MelonLogger.Error("Failed to Apply Moderation, Player was Null");
+                ClassicPlates.Error("Failed to Apply Moderation, Player was Null");
             }
         }
 
@@ -340,14 +340,14 @@ public static class PhotonUtils
         
         if (muted)
         {
-            MelonDebug.Msg("Applying Queued Mute for Player: " + cachedPlayer.ID);
+            ClassicPlates.Debug("Applying Queued Mute for Player: " + cachedPlayer.ID);
 
             if (plate != null) plate.IsMutedBy = true;
         }
         
         if (blocked)
         {
-            MelonDebug.Msg("Applying Queued Block for Player: " + cachedPlayer.ID);
+            ClassicPlates.Debug("Applying Queued Block for Player: " + cachedPlayer.ID);
 
             if (plate != null)
                 plate.IsBlocked = true;
@@ -452,7 +452,7 @@ public static class PhotonUtils
 
             return photonPlayer;
         }
-        MelonLogger.Error("Player Hashtable is Null");
+        ClassicPlates.Error("Player Hashtable is Null");
         return null;
     }
 }


### PR DESCRIPTION
Normal `MelonLogger` has been known to cause issues with a few other mods. This PR is a simple conversion of all `MelonLogger` methods into the newer `MelonLogger.Instance`. This should be more optimized in the grand scheme of things as well as allow this mod to be more compatible with current and future mods.

I have created four easy logging methods in the main MelonMod class: `ClassicPlates.cs`
these are the methods:
`Log(object msg)`
`Debug(object msg)` - should only show if `MelonDebug.IsEnabled()` is true
`Error(object obj)`
`DebugError(object obj)` - should only show if `MelonDebug.IsEnabled()` is true, is normal Error but with a `[DEBUG]` tag on it